### PR TITLE
BR-2 rate limiting 

### DIFF
--- a/src/routes/bookmarkRoutes.js
+++ b/src/routes/bookmarkRoutes.js
@@ -1,11 +1,21 @@
-import express from 'express';
 import bookmarkController from '../controllers/bookmarkController.js';
+import rateLimit from 'express-rate-limit';
 
-const router = express.Router();
+const limiter = rateLimit({
+	windowMs: 15 * 60 * 1000, // 15 minutes
+	limit: 100, // Limit each IP to 100 requests per `window` (here, per 15 minutes).
+	handler: (req, res) => {
+    res.status(429).json({
+      error: "Too many requests, please try again later."
+    });
+  },
+	standardHeaders: 'draft-7', // draft-6: `RateLimit-*` headers; draft-7: combined `RateLimit` header
+	legacyHeaders: false, // Disable the `X-RateLimit-*` headers.
+})
 
 router.get('/bookmarks', bookmarkController.getAllBookmarks);
 router.get('/bookmarks/:id', bookmarkController.getBookmarkById);
-router.post('/bookmarks', bookmarkController.createBookmark);
-router.delete('/bookmarks/:id', bookmarkController.deleteBookmarkById);
+router.post('/bookmarks', limiter, bookmarkController.createBookmark);
+router.delete('/bookmarks/:id', limiter, bookmarkController.deleteBookmarkById);
 
 export default router;


### PR DESCRIPTION
### Introduction of Rate Limiting 

This pull request introduces rate limiting to the `bookmarkRoutes.js` file to enhance the API's security and prevent abuse. The key changes include adding the `express-rate-limit` library and applying rate limiting to specific routes.

#### Enhancements to API Security:

1. **Addition of `express-rate-limit` Library:**
   - Integrated the `express-rate-limit` library to manage the rate limiting functionality.
   - Configuration: Limited each IP to 100 requests per 15 minutes.

2. **Application of Rate Limiting to Specific Routes:**
   - Applied the rate limiter to the `POST /bookmarks` route to prevent abuse.
   - Applied the rate limiter to the `DELETE /bookmarks/:id` route to prevent abuse.